### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # bedrock-veres-one-context ChangeLog
 
+### 12.0.0 - TBD
+### Changed
+- **BREAKING**: Set engines.node >=12.0.0.
+
 ## 11.0.0 - 2021-05-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # bedrock-veres-one-context ChangeLog
 
 ### 12.0.0 - TBD
+
 ### Changed
 - **BREAKING**: Set engines.node >=12.0.0.
 - **BREAKING**: Use bedrock-ledger-context@20.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 12.0.0 - TBD
 ### Changed
 - **BREAKING**: Set engines.node >=12.0.0.
+- **BREAKING**: Use bedrock-ledger-context@20.
 
 ## 11.0.0 - 2021-05-05
 

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "peerDependencies": {
     "bedrock": "2.0.0 - 4.x",
     "bedrock-jsonld-document-loader": "^1.0.1",
-    "bedrock-ledger-context": "^18.0.0"
+    "bedrock-ledger-context": "^20.0.0"
   },
   "engines": {
-    "node": ">=6.3.0"
+    "node": ">=14.0.0"
   },
   "devDependencies": {
     "eslint": "^7.25.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bedrock-ledger-context": "^20.0.0"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=12.0.0"
   },
   "devDependencies": {
     "eslint": "^7.25.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "veres-one-context": "^12.0.0"
   },
   "peerDependencies": {
-    "bedrock": "2.0.0 - 4.x",
+    "bedrock": "^4.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
     "bedrock-ledger-context": "^20.0.0"
   },


### PR DESCRIPTION
Updates `bedrock-ledger-context` to `^20.0.0`
Updates `engines.node` to `>= 14.0.0`

Tests:
1. Was plugged into a multi-node ledger test and caused no issues over 900 ledger writes.