### PR TITLE
Use peer bedrock-ledger-context@21.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 - **BREAKING**: Set engines.node >=12.0.0.
-- **BREAKING**: Use bedrock-ledger-context@20.
+- **BREAKING**: Use bedrock-ledger-context@21.
 
 ### Added
 - Setup test.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "peerDependencies": {
     "bedrock": "^4.0.0",
     "bedrock-jsonld-document-loader": "^1.0.1",
-    "bedrock-ledger-context": "^20.0.0"
+    "bedrock-ledger-context": "^21.0.0"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
Previous round of peer dep updates was never released.

Depends on: https://github.com/digitalbazaar/bedrock-ledger-context/pull/18